### PR TITLE
fix: correct llamacpp server file name reference

### DIFF
--- a/llamacpp.js
+++ b/llamacpp.js
@@ -19,7 +19,7 @@ if (!fs.existsSync(homedir)) {
 const server = async (req, cb) => {
 
   const port = await util.port()
-  const command = "./server"
+  const command = "./llama-server"
   
   //let file = path.resolve(homedir, req.file)
   let file = path.resolve(homedir, "models/huggingface", req.repo, req.file)


### PR DESCRIPTION
llamacpp recently had an update which changed the build/bin/server file to llama-server, which is being called in `llamacpp.js` on line 44 of the spawn function and fails. 

This fixes the `Error: spawn ./server ENOENT`error found in #2 but there may still be errors in the output functions. More details about this problem can be found in that Issue.